### PR TITLE
modify cached frame mismatch warning

### DIFF
--- a/DaiExpandCollectionView/DaiExpandCollectionView/DaiExpandCollectionViewFlowLayout.m
+++ b/DaiExpandCollectionView/DaiExpandCollectionView/DaiExpandCollectionViewFlowLayout.m
@@ -71,12 +71,13 @@ typedef enum {
     CGRect shiftFrame = rect;
     shiftFrame.origin.y -= CGRectGetHeight(self.collectionView.bounds);
     shiftFrame.size.height += CGRectGetHeight(self.collectionView.bounds) * 2;
-    NSArray *attributes = [super layoutAttributesForElementsInRect:shiftFrame];
+    NSMutableArray *attributes = [NSMutableArray array];
+    NSArray *originAttributes = [super layoutAttributesForElementsInRect:shiftFrame];
     
     //運算可視範圍內的 item frame 該是多少
     NSIndexPath *selectedIndexPath = [self.delegate selectedIndexPath];
-    for (int i = 0; i < attributes.count; i++) {
-        UICollectionViewLayoutAttributes *layoutAttributes = attributes[i];
+    for (int i = 0; i < originAttributes.count; i++) {
+        UICollectionViewLayoutAttributes *layoutAttributes = [originAttributes[i] copy];
         CGRect frame = layoutAttributes.frame;
         NSInteger row = layoutAttributes.indexPath.row;
         BOOL isDefaultItem = NO;
@@ -111,6 +112,7 @@ typedef enum {
             frame.origin = [self gridPositionAtIndex:row];
         }
         layoutAttributes.frame = frame;
+        [attributes addObject:layoutAttributes];
     }
     return attributes;
 }


### PR DESCRIPTION
好像是 ios9 會顯示警告

2016-01-29 11:07:44.316 DaiExpandCollectionView[332:55778] Logging only once for UICollectionViewFlowLayout cache mismatched frame
2016-01-29 11:07:44.319 DaiExpandCollectionView[332:55778] UICollectionViewFlowLayout has cached frame mismatch for index path <NSIndexPath: 0xc000000000200016> {length = 2, path = 0 - 1} - cached value: {{215, 5}, {100, 100}}; expected value: {{220, 57.5}, {100, 100}}
2016-01-29 11:07:44.320 DaiExpandCollectionView[332:55778] This is likely occurring because the flow layout subclass DaiExpandCollectionViewFlowLayout is modifying attributes returned by UICollectionViewFlowLayout without copying them

解決方法參考：
https://github.com/mokagio/UICollectionViewLeftAlignedLayout/pull/5/files
